### PR TITLE
49 find by cell

### DIFF
--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -6,6 +6,7 @@
     this._simulation = simulation;
     this._cellRepository = cellRepository;
     this._timeArray = [0];
+    this._parents = [];
   }
 
   CellFactory.prototype.create = function() {
@@ -18,6 +19,9 @@
   CellFactory.prototype.action = function (event) {
     var time = event.source.timing.timestamp;
     if (this._isMating(time, event)) {
+      this._parents.push(event.pairs[0].bodyA.id);
+      this._parents.push(event.pairs[0].bodyB.id);
+      console.log(this._parents)
       this.create();
       this._timeArray.push(time);
     };

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -6,7 +6,6 @@
     this._simulation = simulation;
     this._cellRepository = cellRepository;
     this._timeArray = [0];
-    this._parents = [];
   }
 
   CellFactory.prototype.create = function() {
@@ -19,9 +18,8 @@
   CellFactory.prototype.action = function (event) {
     var time = event.source.timing.timestamp;
     if (this._isMating(time, event)) {
-      this._parents.push(event.pairs[0].bodyA.id);
-      this._parents.push(event.pairs[0].bodyB.id);
-      console.log(this._parents)
+      var parent1 = event.pairs[0].bodyA.id;
+      var parent2 = event.pairs[0].bodyB.id;
       this.create();
       this._timeArray.push(time);
     };

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -18,8 +18,10 @@
   CellFactory.prototype.action = function (event) {
     var time = event.source.timing.timestamp;
     if (this._isMating(time, event)) {
-      var parent1 = event.pairs[0].bodyA.id;
-      var parent2 = event.pairs[0].bodyB.id;
+      var parent1 = this._cellRepository.findCellByBodyId(event.pairs[0].bodyA.id);
+      var parent2 = this._cellRepository.findCellByBodyId(event.pairs[0].bodyB.id);
+      console.log(parent1);
+      console.log(parent2);
       this.create();
       this._timeArray.push(time);
     };

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -15,14 +15,21 @@
     return cell;
   };
 
+  CellFactory.prototype.createFromParents = function (parent1, parent2) {
+    var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
+    var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y)
+    var cell = new Cell(Matter.Bodies.circle(averageXPosition, averageYPosition, 30), new Gait());
+    this._cellRepository.add(cell);
+    this._simulation.addToWorld(cell);
+    return cell;
+  };
+
   CellFactory.prototype.action = function (event) {
     var time = event.source.timing.timestamp;
     if (this._isMating(time, event)) {
       var parent1 = this._cellRepository.findCellByBodyId(event.pairs[0].bodyA.id);
       var parent2 = this._cellRepository.findCellByBodyId(event.pairs[0].bodyB.id);
-      console.log(parent1);
-      console.log(parent2);
-      this.create();
+      this.createFromParents(parent1, parent2);
       this._timeArray.push(time);
     };
   };

--- a/models/CellRepository.js
+++ b/models/CellRepository.js
@@ -14,6 +14,12 @@
     this._store.push(cell);
   };
 
+  CellRepository.prototype.findCellByBodyId = function (id) {
+    return this._store.find(function(cell) {
+      return cell.body().id === id;
+    });
+  };
+
   exports.CellRepository = CellRepository;
 
 })(this);

--- a/models/DecoratedRender.js
+++ b/models/DecoratedRender.js
@@ -15,7 +15,7 @@
     this._matterRender = this._renderModule.create({
                          element: document.body,
                          engine: engine,
-                         options: { width: width, height: height, wireframeBackground: background }
+                         options: { width: width, height: height, wireframeBackground: background, wireframes: false }
                        });
   }
 

--- a/spec/CellRepositorySpec.js
+++ b/spec/CellRepositorySpec.js
@@ -2,7 +2,7 @@
 
 describe("CellRepository", function() {
   var cellRepository;
-  var cell;
+  var mockCell;
 
   beforeEach(function() {
     cellRepository = new CellRepository();
@@ -13,8 +13,18 @@ describe("CellRepository", function() {
   });
 
   it("can hold a cell", function() {
-    cellRepository.add(cell)
-    expect(cellRepository.store()).toContain(cell)
+    cellRepository.add(mockCell)
+    expect(cellRepository.store()).toContain(mockCell)
+  });
+
+  decribe("#findCellByBodyId", function() {
+
+    it("returns the cell with corresponding body id", function() {
+
+
+
+    });
+
   });
 
 });

--- a/spec/CellRepositorySpec.js
+++ b/spec/CellRepositorySpec.js
@@ -2,7 +2,12 @@
 
 describe("CellRepository", function() {
   var cellRepository;
-  var mockCell;
+  var mockBody = {
+    id: 3
+  };
+  var mockCell = {
+    body: function() { return mockBody }
+  };
 
   beforeEach(function() {
     cellRepository = new CellRepository();
@@ -12,16 +17,25 @@ describe("CellRepository", function() {
     expect(cellRepository.store()).toEqual([])
   });
 
-  it("can hold a cell", function() {
-    cellRepository.add(mockCell)
-    expect(cellRepository.store()).toContain(mockCell)
+  describe("#add", function() {
+
+    beforeEach(function() {
+      cellRepository.add(mockCell)
+    });
+
+    it("can hold a cell", function() {
+      expect(cellRepository.store()).toContain(mockCell)
+    });
+
   });
 
   decribe("#findCellByBodyId", function() {
 
+    beforeEach(function() {
+      cellRepository.add(mockCell)
+    });
+
     it("returns the cell with corresponding body id", function() {
-
-
 
     });
 

--- a/spec/CellRepositorySpec.js
+++ b/spec/CellRepositorySpec.js
@@ -29,14 +29,14 @@ describe("CellRepository", function() {
 
   });
 
-  decribe("#findCellByBodyId", function() {
+  describe("#findCellByBodyId", function() {
 
     beforeEach(function() {
       cellRepository.add(mockCell)
     });
 
     it("returns the cell with corresponding body id", function() {
-
+      expect(cellRepository.findCellByBodyId(3)).toEqual(mockCell);
     });
 
   });


### PR DESCRIPTION
Closes #53 
Closes #49 

Code is somewhat lengthy, but it works! 

Now, when collisions happen, the two parents are identified from the collision event, and the child's location is determined by the average of their two positions. 

We added a findCellByBodyId() method to the cellRepository, and we added createFromParents(parent1, parent2) to the cellFactory.

I also turned wireframes off because its PRETTY.  