### PR TITLE
74 inherit shapes

### DIFF
--- a/dawn.js
+++ b/dawn.js
@@ -16,6 +16,8 @@ cellFactory.create();
 cellFactory.create();
 cellFactory.create();
 cellFactory.createSquare();
+cellFactory.createRightAngledTriangle();
+cellFactory.createIsoscelesTriangle();
 
 // register our listeners
 eventController.register('afterUpdate', animator);

--- a/dawn.js
+++ b/dawn.js
@@ -12,9 +12,7 @@ var grow = new Grow(cellRepository);
 decoratedRenderer.createRender(decoratedEngine.matterEngine());
 
 // create some cells
-cellFactory.create();
-cellFactory.create();
-cellFactory.create();
+cellFactory.createCircle();
 cellFactory.createSquare();
 cellFactory.createEquilateralTriangle();
 cellFactory.createRhombus();

--- a/dawn.js
+++ b/dawn.js
@@ -15,6 +15,7 @@ decoratedRenderer.createRender(decoratedEngine.matterEngine());
 cellFactory.create();
 cellFactory.create();
 cellFactory.create();
+cellFactory.createSquare();
 
 // register our listeners
 eventController.register('afterUpdate', animator);

--- a/dawn.js
+++ b/dawn.js
@@ -18,6 +18,7 @@ cellFactory.create();
 cellFactory.createSquare();
 cellFactory.createRightAngledTriangle();
 cellFactory.createIsoscelesTriangle();
+cellFactory.createRhombus();
 
 // register our listeners
 eventController.register('afterUpdate', animator);

--- a/dawn.js
+++ b/dawn.js
@@ -16,8 +16,7 @@ cellFactory.create();
 cellFactory.create();
 cellFactory.create();
 cellFactory.createSquare();
-cellFactory.createRightAngledTriangle();
-cellFactory.createIsoscelesTriangle();
+cellFactory.createEquilateralTriangle();
 cellFactory.createRhombus();
 
 // register our listeners

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -25,6 +25,24 @@
     return cell;
   };
 
+  CellFactory.prototype.createRightAngledTriangle = function () {
+    var x = 10;
+    var vectors = [Matter.Vector.create(4 * x, 3 * x), Matter.Vector.create(-4 * x, 0), Matter.Vector.create(0, -3 * x)];
+    var cell = new Cell(Matter.Bodies.fromVertices(150, 200, vectors), new Gait());
+    this._cellRepository.add(cell);
+    this._simulation.addToWorld(cell);
+    return cell;
+  };
+
+  CellFactory.prototype.createIsoscelesTriangle = function () {
+    var x = 10;
+    var vectors = [Matter.Vector.create(x, 3 * x), Matter.Vector.create(-2 * x, 0), Matter.Vector.create(x, -3 * x)];
+    var cell = new Cell(Matter.Bodies.fromVertices(150, 200, vectors), new Gait());
+    this._cellRepository.add(cell);
+    this._simulation.addToWorld(cell);
+    return cell;
+  };
+
   CellFactory.prototype.createFromParents = function (parent1, parent2) {
     var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
     var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y)

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -43,25 +43,29 @@
     return cell;
   };
 
-  // CellFactory.prototype.createFromParents = function (parent1, parent2) {
-  //   var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
-  //   var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y)
-  //   var cell = new Cell(Matter.Bodies.circle(averageXPosition, averageYPosition, 30), new Gait());
-  //   this._cellRepository.add(cell);
-  //   this._simulation.addToWorld(cell);
-  //   return cell;
-  // };
-
   CellFactory.prototype.createFromParents = function (parent1, parent2) {
     var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
     var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y);
-    var parent1vectors = parent1.body().vertices;
-    // console.log(parent1vectors);
-    var parent2vectors = parent2.body().vertices;
-    var cell = new Cell(Matter.Bodies.fromVertices(averageXPosition, averageYPosition, parent1vectors), new Gait());
+    var cell = new Cell(Matter.Bodies.fromVertices(averageXPosition, averageYPosition, this.concatenateVertices(parent1, parent2)), new Gait());
     this._cellRepository.add(cell);
     this._simulation.addToWorld(cell);
     return cell;
+  };
+
+  CellFactory.prototype.concatenateVertices = function (parent1, parent2) {
+    var vertices = parent1.body().vertices.concat(parent2.body().vertices);
+    var justVertices = []
+    vertices.forEach(function(vertex) {
+      justVertices.push({x: vertex.x, y: vertex.y})
+    })
+    var reducedVertices = justVertices.map(oldObj => {
+      var newObj = {}
+      newObj.x = oldObj.x * 0.65;
+      newObj.y = oldObj.y * 0.65;
+      return newObj;
+    })
+    console.log(reducedVertices);
+    return reducedVertices;
   };
 
   CellFactory.prototype.action = function (event) {

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -35,7 +35,7 @@
   };
 
   CellFactory.prototype.createIsoscelesTriangle = function () {
-    var x = 10;
+    var x = 15;
     var vectors = [Matter.Vector.create(x, 3 * x), Matter.Vector.create(-2 * x, 0), Matter.Vector.create(x, -3 * x)];
     var cell = new Cell(Matter.Bodies.fromVertices(150, 200, vectors), new Gait());
     this._cellRepository.add(cell);

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -43,10 +43,22 @@
     return cell;
   };
 
+  // CellFactory.prototype.createFromParents = function (parent1, parent2) {
+  //   var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
+  //   var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y)
+  //   var cell = new Cell(Matter.Bodies.circle(averageXPosition, averageYPosition, 30), new Gait());
+  //   this._cellRepository.add(cell);
+  //   this._simulation.addToWorld(cell);
+  //   return cell;
+  // };
+
   CellFactory.prototype.createFromParents = function (parent1, parent2) {
     var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
-    var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y)
-    var cell = new Cell(Matter.Bodies.circle(averageXPosition, averageYPosition, 30), new Gait());
+    var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y);
+    var parent1vectors = parent1.body().vertices;
+    // console.log(parent1vectors);
+    var parent2vectors = parent2.body().vertices;
+    var cell = new Cell(Matter.Bodies.fromVertices(averageXPosition, averageYPosition, parent1vectors), new Gait());
     this._cellRepository.add(cell);
     this._simulation.addToWorld(cell);
     return cell;

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -2,14 +2,24 @@
 
 (function(exports) {
 
-  function CellFactory(simulation, cellRepository) {
+  function CellFactory(simulation, cellRepository, vectorModule = Matter.Vector) {
     this._simulation = simulation;
     this._cellRepository = cellRepository;
     this._timeArray = [0];
+    this._vectorModule = vectorModule;
   }
 
   CellFactory.prototype.create = function() {
     var cell = new Cell(Matter.Bodies.circle(150, 200, 30), new Gait());
+    this._cellRepository.add(cell);
+    this._simulation.addToWorld(cell);
+    return cell;
+  };
+
+  CellFactory.prototype.createSquare = function () {
+    var x = 40;
+    var vectors = [Matter.Vector.create(x, 0), Matter.Vector.create(0, x), Matter.Vector.create(-x, 0), Matter.Vector.create(0, -x)]
+    var cell = new Cell(Matter.Bodies.fromVertices(150, 200, vectors), new Gait());
     this._cellRepository.add(cell);
     this._simulation.addToWorld(cell);
     return cell;

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -25,18 +25,9 @@
     return cell;
   };
 
-  CellFactory.prototype.createRightAngledTriangle = function () {
-    var x = 10;
-    var vectors = [Matter.Vector.create(4 * x, 3 * x), Matter.Vector.create(-4 * x, 0), Matter.Vector.create(0, -3 * x)];
-    var cell = new Cell(Matter.Bodies.fromVertices(150, 200, vectors), new Gait());
-    this._cellRepository.add(cell);
-    this._simulation.addToWorld(cell);
-    return cell;
-  };
-
-  CellFactory.prototype.createIsoscelesTriangle = function () {
+  CellFactory.prototype.createEquilateralTriangle = function () {
     var x = 15;
-    var vectors = [Matter.Vector.create(x, 3 * x), Matter.Vector.create(-2 * x, 0), Matter.Vector.create(x, -3 * x)];
+    var vectors = [Matter.Vector.create(1.5 * x, Math.sqrt(6.75) * x), Matter.Vector.create(-3 * x, 0), Matter.Vector.create(1.5 * x, - 1 * Math.sqrt(6.75) * x)];
     var cell = new Cell(Matter.Bodies.fromVertices(150, 200, vectors), new Gait());
     this._cellRepository.add(cell);
     this._simulation.addToWorld(cell);

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -46,26 +46,28 @@
   CellFactory.prototype.createFromParents = function (parent1, parent2) {
     var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
     var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y);
-    var cell = new Cell(Matter.Bodies.fromVertices(averageXPosition, averageYPosition, this.concatenateVertices(parent1, parent2)), new Gait());
+    var inheritedVertices = this._inheritedVertices(parent1, parent2);
+    var cell = new Cell(Matter.Bodies.fromVertices(averageXPosition, averageYPosition, inheritedVertices), new Gait());
     this._cellRepository.add(cell);
     this._simulation.addToWorld(cell);
     return cell;
   };
 
-  CellFactory.prototype.concatenateVertices = function (parent1, parent2) {
-    var vertices = parent1.body().vertices.concat(parent2.body().vertices);
-    var justVertices = []
-    vertices.forEach(function(vertex) {
-      justVertices.push({x: vertex.x, y: vertex.y})
-    })
-    var reducedVertices = justVertices.map(oldObj => {
-      var newObj = {}
-      newObj.x = oldObj.x * 0.65;
-      newObj.y = oldObj.y * 0.65;
-      return newObj;
-    })
-    console.log(reducedVertices);
-    return reducedVertices;
+  CellFactory.prototype._inheritedVertices = function (parent1, parent2) {
+    return this._scaleVertices(this._parentVertices(parent1, parent2), 0.65);
+  };
+
+  CellFactory.prototype._scaleVertices = function (vertices, scaleFactor) {
+    return vertices.map(vertex => {
+      return {
+        x: vertex.x * scaleFactor,
+        y: vertex.y * scaleFactor
+      }
+    });
+  };
+
+  CellFactory.prototype._parentVertices = function (parent1, parent2) {
+    return parent1.body().vertices.concat(parent2.body().vertices);
   };
 
   CellFactory.prototype.action = function (event) {

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -9,7 +9,7 @@
     this._vectorModule = vectorModule;
   }
 
-  CellFactory.prototype.create = function() {
+  CellFactory.prototype.createCircle = function() {
     var cell = new Cell(Matter.Bodies.circle(150, 200, 30), new Gait());
     this._cellRepository.add(cell);
     this._simulation.addToWorld(cell);

--- a/models/CellFactory.js
+++ b/models/CellFactory.js
@@ -43,6 +43,15 @@
     return cell;
   };
 
+  CellFactory.prototype.createRhombus = function () {
+    var x = 25;
+    var vectors = [Matter.Vector.create(2 * x, 0), Matter.Vector.create(0, x), Matter.Vector.create(-2 * x, 0), Matter.Vector.create(0, -x)];
+    var cell = new Cell(Matter.Bodies.fromVertices(150, 200, vectors), new Gait());
+    this._cellRepository.add(cell);
+    this._simulation.addToWorld(cell);
+    return cell;
+  };
+
   CellFactory.prototype.createFromParents = function (parent1, parent2) {
     var averageXPosition = 0.5 * (parent1.body().position.x + parent2.body().position.x);
     var averageYPosition = 0.5 * (parent1.body().position.y + parent2.body().position.y)


### PR DESCRIPTION
Closes #74 

Some major refactoring needed. I suspect a new class should be implemented to manipulate the parents' shapes.

The flow is as follows:
- _scaleVertices() returns the vertices scaled down by a factor to prevent offspring from being too large. This isn't a very maintainable solution unfortunately but I haven't come up with anything better.
- __parentVertices() returns a concatenation of the parents' vertices.
- _inheritedVertices() returns the vertices that will be given to the offspring. In other words, the parentVertices have been scaled.

I've also added functionality to insert square, triangular and rhombus shaped-cells. These use vectors to define these cells but really, we could use matter's built in Bodies methods to generate these in fewer lines.

No tests written as yet because I wasn't sure exactly what we wanted.